### PR TITLE
add NAME attribute

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,10 @@ import logging
 
 logger = logging.getLogger("coffeebreak.core")
 
+PLUGIN_TITLE = "event-schedule-plugin"
+NAME = "Event Schedule Plugin"
+DESCRIPTION = "A plugin for displaying an event schedule"
+
 def register_plugin():
     ComponentRegistry.register_component(Schedule)
     logger.debug("Schedule component registered.")


### PR DESCRIPTION
This pull request introduces new constants to the `__init__.py` file for better plugin metadata management. These constants provide a clear and centralized way to define the plugin's title, name, and description.

### Metadata additions:

* [`__init__.py`](diffhunk://#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cR7-R10): Added `PLUGIN_TITLE`, `NAME`, and `DESCRIPTION` constants to define the plugin's metadata, including its title ("event-schedule-plugin"), name ("Event Schedule Plugin"), and description ("A plugin for displaying an event schedule").

Related Jira Ticket: SCRUM-371